### PR TITLE
Litestream read/write split with HTTP load balancer

### DIFF
--- a/litestream/README.md
+++ b/litestream/README.md
@@ -1,6 +1,12 @@
 # Litestream on Cloud Storage + Cloud Run
 
-This demonstrates running a Cloud Run service that uses the [Litestream VFS](https://litestream.io/guides/vfs/) to read and write a SQLite database directly through a replica in Google Cloud Storage.
+This demonstrates running Cloud Run services that use the [Litestream VFS](https://litestream.io/guides/vfs/) to read and write a SQLite database directly through a replica in Google Cloud Storage.
+
+Production traffic uses two services plus an HTTP load balancer:
+
+- **`litestream-reader`** — read-only VFS (`LITESTREAM_WRITE_ENABLED=false`), serves `GET /`, scales out (up to 10 instances).
+- **`litestream-writer`** — write-enabled VFS, serves `POST /click` only, single instance.
+- **HTTP load balancer** — routes `/click` to the writer and all other paths to the reader so htmx can use relative URLs on one hostname (`lb_url` output).
 
 ## How it works
 
@@ -18,9 +24,23 @@ This uses [`mattn/go-sqlite3`](https://github.com/mattn/go-sqlite3), a CGO-based
 
 The `vfs` build tag is required to compile the Litestream VFS code (`GOFLAGS=-tags=vfs`).
 
+## Environment variables
+
+| Variable | Reader | Writer |
+|----------|--------|--------|
+| `LITESTREAM_REPLICA_URL` | required | required |
+| `LITESTREAM_WRITE_ENABLED` | `false` | `true` |
+| `LITESTREAM_BUFFER_PATH` | — | path for write buffer (in-memory volume) |
+
+After `terraform apply`, open the **`lb_url`** output for the UI. Direct `reader_url` / `writer_url` remain available for debugging.
+
+Deploy the **writer** at least once before readers on a fresh bucket so the schema exists in the replica.
+
 ## Limitations
 
-**Single writer only.** The Litestream VFS write mode uses optimistic conflict detection, not distributed locking. The Cloud Run service is configured with `max_instance_count = 1`. Running multiple writers will result in conflicts.
+**Single writer only.** The Litestream VFS write mode uses optimistic conflict detection, not distributed locking. Only `litestream-writer` may have `LITESTREAM_WRITE_ENABLED=true`. Running multiple writers against the same replica will result in conflicts.
+
+Reader counts may lag writes by about the VFS poll interval plus the writer sync interval (both default to 1 second).
 
 The VFS write buffer is stored on an in-memory `empty_dir` volume, so it is lost when the instance scales to zero. The VFS will rebuild from the GCS replica on the next cold start, fetching pages on-demand rather than requiring a full restore.
 
@@ -63,4 +83,4 @@ There are also potentially tenancy benefits to using a separate database for eac
 
 ### Running locally
 
-Since the database is just SQLite, it's very easy to run this locally. Simply `go run -tags vfs ./` and the service will create `db.sqlite` in the current directory (without VFS — the VFS is only used when running on GCE). You can browse to http://localhost:8080/ to see the service running, and interact with the database using standard tools.
+Since the database is just SQLite, it's very easy to run this locally. `go run -tags vfs ./` starts a single process with both `GET /` and `POST /click` (no VFS on laptop — VFS is only used on GCE). Browse to http://localhost:8080/.

--- a/litestream/lb.tf
+++ b/litestream/lb.tf
@@ -1,0 +1,98 @@
+// HTTP load balancer: GET /* -> reader, POST /click -> writer (same hostname for htmx).
+
+data "google_project" "project" {
+  project_id = local.project_id
+}
+
+resource "google_compute_global_address" "litestream" {
+  name = "litestream-lb"
+}
+
+resource "google_compute_region_network_endpoint_group" "reader" {
+  name                  = "litestream-reader-neg"
+  region                = local.region
+  network_endpoint_type = "SERVERLESS"
+
+  cloud_run {
+    service = google_cloud_run_v2_service.reader.name
+  }
+}
+
+resource "google_compute_region_network_endpoint_group" "writer" {
+  name                  = "litestream-writer-neg"
+  region                = local.region
+  network_endpoint_type = "SERVERLESS"
+
+  cloud_run {
+    service = google_cloud_run_v2_service.writer.name
+  }
+}
+
+resource "google_compute_backend_service" "reader" {
+  name        = "litestream-reader-backend"
+  protocol    = "HTTP"
+  port_name   = "http"
+  timeout_sec = 30
+
+  backend {
+    group = google_compute_region_network_endpoint_group.reader.id
+  }
+}
+
+resource "google_compute_backend_service" "writer" {
+  name        = "litestream-writer-backend"
+  protocol    = "HTTP"
+  port_name   = "http"
+  timeout_sec = 30
+
+  backend {
+    group = google_compute_region_network_endpoint_group.writer.id
+  }
+}
+
+resource "google_compute_url_map" "litestream" {
+  name            = "litestream-url-map"
+  default_service = google_compute_backend_service.reader.id
+
+  host_rule {
+    hosts        = ["*"]
+    path_matcher = "paths"
+  }
+
+  path_matcher {
+    name            = "paths"
+    default_service = google_compute_backend_service.reader.id
+
+    path_rule {
+      paths   = ["/click"]
+      service = google_compute_backend_service.writer.id
+    }
+  }
+}
+
+resource "google_compute_target_http_proxy" "litestream" {
+  name    = "litestream-http-proxy"
+  url_map = google_compute_url_map.litestream.id
+}
+
+resource "google_compute_global_forwarding_rule" "litestream" {
+  name       = "litestream-http-forwarding"
+  target     = google_compute_target_http_proxy.litestream.id
+  port_range = "80"
+  ip_address = google_compute_global_address.litestream.address
+}
+
+// Allow the external HTTP load balancer to invoke Cloud Run.
+resource "google_cloud_run_v2_service_iam_member" "reader_lb" {
+  name     = google_cloud_run_v2_service.reader.name
+  location = google_cloud_run_v2_service.reader.location
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com"
+}
+
+resource "google_cloud_run_v2_service_iam_member" "writer_lb" {
+  name     = google_cloud_run_v2_service.writer.name
+  location = google_cloud_run_v2_service.writer.location
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com"
+}

--- a/litestream/main.go
+++ b/litestream/main.go
@@ -8,6 +8,7 @@ import (
 	"html/template"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 
 	"cloud.google.com/go/compute/metadata"
@@ -21,15 +22,32 @@ import (
 
 var dbfile = flag.String("file", "db.sqlite", "path to database file")
 
+func writeEnabled() bool {
+	v := os.Getenv("LITESTREAM_WRITE_ENABLED")
+	if v == "" {
+		return false
+	}
+	enabled, err := strconv.ParseBool(v)
+	if err != nil {
+		clog.Fatalf("invalid LITESTREAM_WRITE_ENABLED %q: %v", v, err)
+	}
+	return enabled
+}
+
 func main() {
 	flag.Parse()
 
 	dbfile := *dbfile
 	dsn := dbfile
+	onGCE := metadata.OnGCE()
+	writer := writeEnabled()
+	serveReads := !onGCE || !writer
+	serveWrites := !onGCE || writer
 
 	log := clog.FromContext(context.Background())
+	clog.Infof("litestream routes", "on_gce", onGCE, "writer", writer, "serve_reads", serveReads, "serve_writes", serveWrites)
 
-	if metadata.OnGCE() {
+	if onGCE {
 		replicaURL := os.Getenv("LITESTREAM_REPLICA_URL")
 		if replicaURL == "" {
 			clog.Fatal("LITESTREAM_REPLICA_URL environment variable is required on GCE")
@@ -43,22 +61,23 @@ func main() {
 			clog.Fatalf("failed to init replica client: %v", err)
 		}
 
-		vfs := litestream.NewVFS(client, &log.Logger)
+		vfs := litestream.NewVFS(client, log.Base())
 		vfs.PollInterval = 1 * time.Second
-		vfs.WriteEnabled = true
-		vfs.WriteSyncInterval = 1 * time.Second
-
-		if bufPath := os.Getenv("LITESTREAM_BUFFER_PATH"); bufPath != "" {
-			vfs.WriteBufferPath = bufPath
+		vfs.WriteEnabled = writer
+		if writer {
+			vfs.WriteSyncInterval = 1 * time.Second
+			if bufPath := os.Getenv("LITESTREAM_BUFFER_PATH"); bufPath != "" {
+				vfs.WriteBufferPath = bufPath
+			}
 		}
 
-		clog.Infof("registering litestream VFS...")
+		clog.Infof("registering litestream VFS...", "write_enabled", writer)
 		if err := sqlite3vfs.RegisterVFS("litestream", vfs); err != nil {
 			clog.Fatalf("failed to register VFS: %v", err)
 		}
 		clog.Infof("litestream VFS registered")
 
-		dsn = "file:db?vfs=litestream"
+		dsn = "file:db?vfs=litestream&_busy_timeout=5000"
 	}
 
 	db, err := sql.Open("sqlite3", dsn)
@@ -67,65 +86,108 @@ func main() {
 	}
 	defer db.Close()
 
-	if _, err := db.Exec("create table if not exists test3 (time integer primary key)"); err != nil {
-		clog.Fatalf("failed to create table: %v", err)
+	if serveWrites {
+		if onGCE || !dbExists(dbfile) {
+			if _, err := db.Exec("create table if not exists test3 (time integer primary key)"); err != nil {
+				clog.Fatalf("failed to create table: %v", err)
+			}
+		}
 	}
 
 	http.HandleFunc("/favicon.ico", func(w http.ResponseWriter, r *http.Request) { http.Error(w, "no favicon", http.StatusNotFound) })
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		data, err := getData(db, true)
-		if err != nil {
-			clog.Fatalf("failed to get data: %v", err)
-		}
-		if err := page.Execute(w, data); err != nil {
-			clog.Fatalf("failed to execute template: %v", err)
-		}
-	})
-	http.HandleFunc("/click", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		data, err := getData(db, false)
-		if err != nil {
-			clog.Fatalf("failed to get data: %v", err)
-		}
-		if err := div.Execute(w, data); err != nil {
-			clog.Fatalf("failed to execute template: %v", err)
-		}
-	})
+
+	if serveReads {
+		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			data, err := readPageData(db)
+			if err != nil {
+				if onGCE {
+					clog.Errorf("failed to read page data: %v", err)
+					http.Error(w, "internal server error", http.StatusInternalServerError)
+					return
+				}
+				clog.Fatalf("failed to read page data: %v", err)
+			}
+			if err := page.Execute(w, data); err != nil {
+				if onGCE {
+					clog.Errorf("failed to execute template: %v", err)
+					http.Error(w, "internal server error", http.StatusInternalServerError)
+					return
+				}
+				clog.Fatalf("failed to execute template: %v", err)
+			}
+		})
+	}
+
+	if serveWrites {
+		http.HandleFunc("/click", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPost {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			data, err := incrementAndCount(db)
+			if err != nil {
+				if onGCE {
+					clog.Errorf("failed to increment: %v", err)
+					http.Error(w, "internal server error", http.StatusInternalServerError)
+					return
+				}
+				clog.Fatalf("failed to increment: %v", err)
+			}
+			if err := div.Execute(w, data); err != nil {
+				if onGCE {
+					clog.Errorf("failed to execute template: %v", err)
+					http.Error(w, "internal server error", http.StatusInternalServerError)
+					return
+				}
+				clog.Fatalf("failed to execute template: %v", err)
+			}
+		})
+	}
+
 	clog.Fatal("ListenAndServe", "err", http.ListenAndServe(":8080", nil))
 }
 
-func getData(db *sql.DB, getVersion bool) (data, error) {
+func readPageData(db *sql.DB) (data, error) {
 	var version string
-	if getVersion {
-		row := db.QueryRow("select sqlite_version()")
-		if err := row.Scan(&version); err != nil {
-			return data{}, fmt.Errorf("failed to query database version: %w", err)
-		}
+	row := db.QueryRow("select sqlite_version()")
+	if err := row.Scan(&version); err != nil {
+		return data{}, fmt.Errorf("failed to query database version: %w", err)
 	}
 
+	count, err := queryCount(db)
+	if err != nil {
+		return data{}, err
+	}
+	return data{Version: version, Count: count}, nil
+}
+
+func incrementAndCount(db *sql.DB) (data, error) {
 	if _, err := db.Exec("insert into test3 (time) values (cast(unixepoch('now','subsec') * 1000 as integer))"); err != nil {
 		return data{}, fmt.Errorf("failed to insert row: %w", err)
 	}
-	rows, err := db.Query("select count(*) from test3")
+	count, err := queryCount(db)
 	if err != nil {
-		return data{}, fmt.Errorf("failed to query rows: %w", err)
+		return data{}, err
 	}
-	defer rows.Close()
-	for rows.Next() {
-		var count int
-		if err := rows.Scan(&count); err != nil {
-			return data{}, fmt.Errorf("failed to scan row: %w", err)
-		}
-		return data{Version: version, Count: count}, nil
+	return data{Count: count}, nil
+}
+
+func dbExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func queryCount(db *sql.DB) (int, error) {
+	row := db.QueryRow("select count(*) from test3")
+	var count int
+	if err := row.Scan(&count); err != nil {
+		return 0, fmt.Errorf("failed to query count: %w", err)
 	}
-	return data{}, fmt.Errorf("failed to get count")
+	return count, nil
 }
 
 type data struct {

--- a/litestream/main.tf
+++ b/litestream/main.tf
@@ -2,14 +2,19 @@
 
 terraform {
   required_providers {
-    ko  = { source = "ko-build/ko" }
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+    ko = { source = "ko-build/ko" }
     oci = { source = "chainguard-dev/oci" }
   }
 }
 
 locals {
-  project_id = "jason-chainguard"
-  region     = "us-central1"
+  project_id  = "jason-chainguard"
+  region      = "us-central1"
+  replica_url = "gs://${google_storage_bucket.bucket.name}/litestream"
 }
 
 provider "google" {
@@ -52,23 +57,51 @@ resource "ko_build" "build" {
   ]
 }
 
-resource "google_cloud_run_v2_service" "service" {
-  provider = google-beta // for empty_dir
+resource "google_cloud_run_v2_service" "reader" {
+  provider = google-beta
 
-  name         = "litestream"
+  name         = "litestream-reader"
   location     = local.region
   launch_stage = "BETA"
   ingress      = "INGRESS_TRAFFIC_ALL"
 
   template {
     scaling {
-      // Litestream VFS write mode uses optimistic conflict detection,
-      // not distributed locking. Only a single writer is supported.
+      max_instance_count = 10
+    }
+
+    max_instance_request_concurrency = 1000
+
+    service_account = google_service_account.sa.email
+
+    containers {
+      image = ko_build.build.image_ref
+      env {
+        name  = "LITESTREAM_REPLICA_URL"
+        value = local.replica_url
+      }
+      env {
+        name  = "LITESTREAM_WRITE_ENABLED"
+        value = "false"
+      }
+    }
+  }
+}
+
+resource "google_cloud_run_v2_service" "writer" {
+  provider = google-beta // for empty_dir
+
+  name         = "litestream-writer"
+  location     = local.region
+  launch_stage = "BETA"
+  ingress      = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    scaling {
       max_instance_count = 1
     }
 
-    // Allow max concurrent requests to the single replica.
-    max_instance_request_concurrency = 1000
+    max_instance_request_concurrency = 250
 
     service_account = google_service_account.sa.email
 
@@ -80,7 +113,11 @@ resource "google_cloud_run_v2_service" "service" {
       }
       env {
         name  = "LITESTREAM_REPLICA_URL"
-        value = "gs://${google_storage_bucket.bucket.name}/litestream"
+        value = local.replica_url
+      }
+      env {
+        name  = "LITESTREAM_WRITE_ENABLED"
+        value = "true"
       }
       env {
         name  = "LITESTREAM_BUFFER_PATH"
@@ -98,12 +135,21 @@ resource "google_cloud_run_v2_service" "service" {
   }
 }
 
-// Allow all users to invoke the service
-resource "google_cloud_run_v2_service_iam_member" "public" {
-  name   = google_cloud_run_v2_service.service.name
-  role   = "roles/run.invoker"
-  member = "allUsers"
+resource "google_cloud_run_v2_service_iam_member" "reader_public" {
+  name     = google_cloud_run_v2_service.reader.name
+  location = google_cloud_run_v2_service.reader.location
+  role     = "roles/run.invoker"
+  member   = "allUsers"
 }
 
-output "url" { value = google_cloud_run_v2_service.service.uri }
+resource "google_cloud_run_v2_service_iam_member" "writer_public" {
+  name     = google_cloud_run_v2_service.writer.name
+  location = google_cloud_run_v2_service.writer.location
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+output "reader_url" { value = google_cloud_run_v2_service.reader.uri }
+output "writer_url" { value = google_cloud_run_v2_service.writer.uri }
+output "lb_url" { value = "http://${google_compute_global_address.litestream.address}" }
 output "app-image" { value = ko_build.build.image_ref }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Splits the litestream demo into a **read-only reader** tier and a **single writer** tier, fronted by a global HTTP load balancer so htmx can keep using relative `/click` URLs on one hostname.

## Application

- `GET /` only runs `SELECT` (no insert on page load).
- `POST /click` is the only write path.
- `LITESTREAM_WRITE_ENABLED` controls VFS write mode and which routes are registered on GCE.
- Local dev (`!OnGCE`) still serves both routes from one process.

## Infrastructure

- `litestream-reader`: `WRITE_ENABLED=false`, `max_instance_count = 10`, concurrency 1000
- `litestream-writer`: `WRITE_ENABLED=true`, `max_instance_count = 1`, in-memory write buffer volume
- `lb.tf`: HTTP LB routes `/click` → writer, default → reader

## Outputs

- `lb_url` — use this for the demo UI
- `reader_url` / `writer_url` — direct Cloud Run URLs for debugging

## Deploy notes

Apply writer (or hit writer once) before readers on a fresh GCS replica so `test3` exists. Reader counts may lag writes by ~1–2s (poll + sync intervals).

## Testing

```bash
cd litestream
GOFLAGS=-tags=vfs go build .
GOFLAGS=-tags=vfs go run .
# http://localhost:8080/
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019e763d-bffe-796d-9651-64880c0810d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019e763d-bffe-796d-9651-64880c0810d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

